### PR TITLE
fix jump hashing instance ring order

### DIFF
--- a/hashing/jump.go
+++ b/hashing/jump.go
@@ -93,7 +93,7 @@ func (chr *JumpHashRing) AddNode(node Node) {
 		chr.ring = append(chr.ring, node)
 	} else {
 		i := 0
-		for i = 0; i < chr.Len() && node.Instance <= chr.ring[i].Instance; i++ {
+		for i = 0; i < chr.Len() && node.Instance >= chr.ring[i].Instance; i++ {
 		}
 		chr.ring = append(chr.ring, node)  // Make room
 		copy(chr.ring[i+1:], chr.ring[i:]) // Shuffle array

--- a/hashing/jump_test.go
+++ b/hashing/jump_test.go
@@ -137,13 +137,13 @@ func TestJumpCHRInstanceOrder(t *testing.T) {
 	chr := makeJumpTestCHRWithInstanceName(1)
 	t.Logf(chr.String())
 	//Order the slice of nodes by instance name
-	o_nodes := make(nodesSlice, len(jumpHashTestNodesWithInstanceName))
-	copy(o_nodes, jumpHashTestNodesWithInstanceName)
-	sort.Sort(o_nodes)
+	oNodes := make(nodesSlice, len(jumpHashTestNodesWithInstanceName))
+	copy(oNodes, jumpHashTestNodesWithInstanceName)
+	sort.Sort(oNodes)
 	//Check that the nodes in the ring are correctly ordered by instance name
 	for index, n := range chr.ring {
-		if n.Server != o_nodes[index][0] {
-			t.Errorf("Wrong order in jump hash ring: expected to find: '%s', found %s", n.Server, o_nodes[index][0])
+		if n.Server != oNodes[index][0] {
+			t.Errorf("Wrong order in jump hash ring: expected to find: '%s', found %s", n.Server, oNodes[index][0])
 		}
 	}
 }

--- a/hashing/jump_test.go
+++ b/hashing/jump_test.go
@@ -133,7 +133,7 @@ func TestJumpCHR(t *testing.T) {
 	}
 }
 
-func TestJumpCHRWithInstanceName(t *testing.T) {
+func TestJumpCHRInstanceOrder(t *testing.T) {
 	chr := makeJumpTestCHRWithInstanceName(1)
 	t.Logf(chr.String())
 	//Order the slice of nodes by instance name


### PR DESCRIPTION
The aim of this pull request is to fix a bug with the sort order of the nodes when using the jump hashring in combination with instance labels.

I also added a test to check the modified behaviour.