### PR TITLE
bucky: first stab at supporting fnv1a_ch hash algo

### DIFF
--- a/buckytools.go
+++ b/buckytools.go
@@ -13,6 +13,7 @@ const (
 // used for the consistent hash ring.  This slice must be sorted.
 var SupportedHashTypes = []string{
 	"carbon",
+	"fnv1a",
 	"jump_fnv1a",
 }
 

--- a/cmd/bucky/cluster.go
+++ b/cmd/bucky/cluster.go
@@ -68,6 +68,8 @@ func GetClusterConfig(hostport string) (*ClusterConfig, error) {
 	switch master.Algo {
 	case "carbon":
 		Cluster.Hash = hashing.NewCarbonHashRing()
+	case "fnv1a":
+		Cluster.Hash = hashing.NewFNV1aHashRing()
 	case "jump_fnv1a":
 		Cluster.Hash = hashing.NewJumpHashRing(master.Replicas)
 	default:

--- a/cmd/findhash/main.go
+++ b/cmd/findhash/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -98,12 +99,33 @@ func makeRing(config []string) *hashing.CarbonHashRing {
 	hr := hashing.NewCarbonHashRing()
 	for _, n := range config {
 		fields := strings.Split(n, ":")
-		if len(fields) < 2 {
+		if len(fields) == 1 {
+			fields = append(fields, "2003")
 			fields = append(fields, uuid.New())
-		} else if fields[1] == "" {
-			fields[1] = uuid.New()
+		} else if len(fields) == 2 {
+			_, err := strconv.Atoi(fields[1])
+			if err != nil {
+				// assume instance
+				fields = append(fields, fields[1])
+				fields[1] = "2003"
+			} else {
+				fields = append(fields, uuid.New())
+			}
+		} else {
+			// 3 or more fields
+			fields = fields[:3]
 		}
-		hr.AddNode(hashing.NewNode(fields[0], fields[1]))
+		if fields[1] == "" {
+			fields[1] = "2003"
+		}
+		if fields[2] == "" {
+			fields[2] = uuid.New()
+		}
+		port, err := strconv.ParseUint(fields[1], 10, 16)
+		if err != nil {
+			port = 2003
+		}
+		hr.AddNode(hashing.NewNode(fields[0], uint(port), fields[2]))
 	}
 
 	return hr

--- a/hashing/hashing_test.go
+++ b/hashing/hashing_test.go
@@ -7,57 +7,57 @@ import (
 
 func makeRing() *CarbonHashRing {
 	hr := NewCarbonHashRing()
-	hr.AddNode(NewNode("graphite010-g5", "a"))
-	hr.AddNode(NewNode("graphite010-g5", "b"))
-	hr.AddNode(NewNode("graphite010-g5", "c"))
+	hr.AddNode(NewNode("graphite010-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite010-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite010-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite011-g5", "a"))
-	hr.AddNode(NewNode("graphite011-g5", "b"))
-	hr.AddNode(NewNode("graphite011-g5", "c"))
+	hr.AddNode(NewNode("graphite011-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite011-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite011-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite012-g5", "a"))
-	hr.AddNode(NewNode("graphite012-g5", "b"))
-	hr.AddNode(NewNode("graphite012-g5", "c"))
+	hr.AddNode(NewNode("graphite012-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite012-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite012-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite013-g5", "a"))
-	hr.AddNode(NewNode("graphite013-g5", "b"))
-	hr.AddNode(NewNode("graphite013-g5", "c"))
+	hr.AddNode(NewNode("graphite013-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite013-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite013-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite014-g5", "a"))
-	hr.AddNode(NewNode("graphite014-g5", "b"))
-	hr.AddNode(NewNode("graphite014-g5", "c"))
+	hr.AddNode(NewNode("graphite014-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite014-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite014-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite015-g5", "a"))
-	hr.AddNode(NewNode("graphite015-g5", "b"))
-	hr.AddNode(NewNode("graphite015-g5", "c"))
+	hr.AddNode(NewNode("graphite015-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite015-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite015-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite016-g5", "a"))
-	hr.AddNode(NewNode("graphite016-g5", "b"))
-	hr.AddNode(NewNode("graphite016-g5", "c"))
+	hr.AddNode(NewNode("graphite016-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite016-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite016-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite017-g5", "a"))
-	hr.AddNode(NewNode("graphite017-g5", "b"))
-	hr.AddNode(NewNode("graphite017-g5", "c"))
+	hr.AddNode(NewNode("graphite017-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite017-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite017-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite018-g5", "a"))
-	hr.AddNode(NewNode("graphite018-g5", "b"))
-	hr.AddNode(NewNode("graphite018-g5", "c"))
+	hr.AddNode(NewNode("graphite018-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite018-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite018-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite-data019-g5", "a"))
-	hr.AddNode(NewNode("graphite-data019-g5", "b"))
-	hr.AddNode(NewNode("graphite-data019-g5", "c"))
+	hr.AddNode(NewNode("graphite-data019-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite-data019-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite-data019-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite-data020-g5", "a"))
-	hr.AddNode(NewNode("graphite-data020-g5", "b"))
-	hr.AddNode(NewNode("graphite-data020-g5", "c"))
+	hr.AddNode(NewNode("graphite-data020-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite-data020-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite-data020-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite-data021-g5", "a"))
-	hr.AddNode(NewNode("graphite-data021-g5", "b"))
-	hr.AddNode(NewNode("graphite-data021-g5", "c"))
+	hr.AddNode(NewNode("graphite-data021-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite-data021-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite-data021-g5", 0, "c"))
 
-	hr.AddNode(NewNode("graphite-data022-g5", "a"))
-	hr.AddNode(NewNode("graphite-data022-g5", "b"))
-	hr.AddNode(NewNode("graphite-data022-g5", "c"))
+	hr.AddNode(NewNode("graphite-data022-g5", 0, "a"))
+	hr.AddNode(NewNode("graphite-data022-g5", 0, "b"))
+	hr.AddNode(NewNode("graphite-data022-g5", 0, "c"))
 
 	return hr
 }
@@ -66,7 +66,7 @@ func TestEmptyInstance(t *testing.T) {
 	hr := NewCarbonHashRing()
 
 	for _, s := range []string{"test01", "test02"} {
-		n := NewNode(s, "")
+		n := NewNode(s, 0, "")
 		hr.AddNode(n)
 	}
 
@@ -84,12 +84,12 @@ func TestEmptyInstance(t *testing.T) {
 }
 
 func TestNewNode(t *testing.T) {
-	n := NewNode("graphite010-g5", "a")
+	n := NewNode("graphite010-g5", 0, "a")
 	if n.KeyValue() != "('graphite010-g5', 'a')" {
 		t.Error("NewNode() did not produce a tuple string format")
 	}
 
-	if NewNode("graphite011-g5", "").KeyValue() != "('graphite011-g5', None)" {
+	if NewNode("graphite011-g5", 0, "").KeyValue() != "('graphite011-g5', None)" {
 		t.Error("NewNode() did not handle a None instance value")
 	}
 
@@ -113,7 +113,7 @@ func TestNewHashRing(t *testing.T) {
 		t.Error("HashRing replica setting error")
 	}
 
-	n := NewNode("a", "a")
+	n := NewNode("a", 0, "a")
 	hr.AddNode(n)
 	if hr.String() != "[carbon: 1 nodes, 5 replicas, 5 ring members a:a]" {
 		t.Error("HashRing string representation or AddNode()")


### PR DESCRIPTION
Support fnv1a_ch next to carbon_ch.  This means port needs to be
recognised, which can be given in the form HOST[:PORT[:INSTANCE]].  The
previous form of HOST[:INSTANCE] is still supported by parsing instance
as a number, if so, it is assumed to be a port.

I would like some basic review on the sanity of this change.  I can't imagine everything works as expected this way.